### PR TITLE
COMPASS-2435: refresh stats when instance is refreshed

### DIFF
--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -46,6 +46,13 @@ const CollectionStatsStore = Reflux.createStore({
         this.onCollectionChanged();
       }
     });
+    appRegistry.on('instance-refreshed', () => {
+      const ns = appRegistry.getStore('App.NamespaceStore').ns;
+      if (ns.indexOf('.' === 0)) {
+        this.onDocumentsModified();
+        this.onCollectionChanged();
+      }
+    });
   },
 
   /**

--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -39,13 +39,6 @@ const CollectionStatsStore = Reflux.createStore({
     appRegistry.on('import-finished', this.onDocumentsModified.bind(this));
     appRegistry.on('data-service-connected', this.onConnected.bind(this));
     appRegistry.on('collection-changed', this.onCollectionChanged.bind(this));
-    appRegistry.on('refresh-data', () => {
-      const ns = appRegistry.getStore('App.NamespaceStore').ns;
-      if (ns.indexOf('.' === 0)) {
-        this.onDocumentsModified();
-        this.onCollectionChanged();
-      }
-    });
     appRegistry.on('instance-refreshed', () => {
       const ns = appRegistry.getStore('App.NamespaceStore').ns;
       if (ns.indexOf('.' === 0)) {


### PR DESCRIPTION
`refreshInstance()` is now emitting a `instance-refreshed` event that we can handle in this component. 

Since `refreshInstance()` is always called when we are doing a `refresh-data` event, we can remove that handler here.

related compass [PR](https://github.com/10gen/compass/pull/1502)