### PR TITLE
Exclude source map and index.html generated for electron from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,5 @@ scripts/
 src/
 test/
 .storybook/
+lib/index.html
+lib/index.js.map


### PR DESCRIPTION
 Saves 110Kb when `npm install`'d

```
-rw-r--r--   1 lucas  staff   183B May  2 11:11 index.html
-rw-r--r--   1 lucas  staff    31K May  2 11:11 index.js
-rw-r--r--   1 lucas  staff   110K May  2 11:11 index.js.map
```